### PR TITLE
Update workflows for publishing images to ECR

### DIFF
--- a/.github/workflows/server-build.yml
+++ b/.github/workflows/server-build.yml
@@ -9,13 +9,16 @@ on:
     paths: ['server/**']
 
 env:
-  IMAGE_NAME: chz160/joinery-server
+  DOCKERHUB_IMAGE: chz160/joinery-server
+  ECR_PRIVATE_IMAGE: 832763959711.dkr.ecr.us-east-1.amazonaws.com/joinery-server
+  ECR_PUBLIC_IMAGE: public.ecr.aws/n4s7h4e9/joinery-server
 
 jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
 
     steps:
       - name: Checkout repository
@@ -31,11 +34,32 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
+      - name: Configure AWS credentials
+        if: github.event_name != 'pull_request'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Log in to Amazon ECR Private
+        if: github.event_name != 'pull_request'
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Log in to Amazon ECR Public
+        if: github.event_name != 'pull_request'
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
       - name: Extract metadata (tags, labels)
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.IMAGE_NAME }}
+          images: |
+            ${{ env.DOCKERHUB_IMAGE }}
+            ${{ env.ECR_PRIVATE_IMAGE }}
+            ${{ env.ECR_PUBLIC_IMAGE }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix=sha-
@@ -58,7 +82,7 @@ jobs:
         run: |
           echo "## Docker Image Published" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Image:** $IMAGE_NAME" >> $GITHUB_STEP_SUMMARY
+          echo "**Registries:** Docker Hub + ECR Private + ECR Public" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Tags:" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -9,13 +9,16 @@ on:
     paths: ['web/**']
 
 env:
-  IMAGE_NAME: chz160/joinery-web
+  DOCKERHUB_IMAGE: chz160/joinery-web
+  ECR_PRIVATE_IMAGE: 832763959711.dkr.ecr.us-east-1.amazonaws.com/joinery-web
+  ECR_PUBLIC_IMAGE: public.ecr.aws/n4s7h4e9/joinery-web
 
 jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
 
     steps:
       - name: Checkout repository
@@ -31,11 +34,32 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
+      - name: Configure AWS credentials
+        if: github.event_name != 'pull_request'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Log in to Amazon ECR Private
+        if: github.event_name != 'pull_request'
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Log in to Amazon ECR Public
+        if: github.event_name != 'pull_request'
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
       - name: Extract metadata (tags, labels)
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.IMAGE_NAME }}
+          images: |
+            ${{ env.DOCKERHUB_IMAGE }}
+            ${{ env.ECR_PRIVATE_IMAGE }}
+            ${{ env.ECR_PUBLIC_IMAGE }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix=sha-
@@ -57,7 +81,7 @@ jobs:
         run: |
           echo "## Docker Image Published" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Image:** $IMAGE_NAME" >> $GITHUB_STEP_SUMMARY
+          echo "**Registries:** Docker Hub + ECR Private + ECR Public" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Tags:" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -54,9 +54,18 @@ npm start
 
 GitHub Actions workflows in `.github/workflows/`:
 
-- **`server-build.yml`** — Builds and pushes `chz160/joinery-server` to Docker Hub on `server/**` changes
-- **`web-build.yml`** — Builds and pushes `chz160/joinery-web` to Docker Hub on `web/**` changes
+- **`server-build.yml`** — Builds and pushes the server image on `server/**` changes
+- **`web-build.yml`** — Builds and pushes the web image on `web/**` changes
 - **`deploy.yml`** — Deploys the full stack via SSH and docker-compose
+
+### Docker Images
+
+Each build pushes to three registries:
+
+| Image | Docker Hub | ECR Public |
+|-------|-----------|------------|
+| **Server** | `chz160/joinery-server` | `public.ecr.aws/n4s7h4e9/joinery-server` |
+| **Web** | `chz160/joinery-web` | `public.ecr.aws/n4s7h4e9/joinery-web` |
 
 ### Required GitHub Secrets
 
@@ -64,6 +73,8 @@ GitHub Actions workflows in `.github/workflows/`:
 |--------|---------|
 | `DOCKER_HUB_USERNAME` | Docker Hub login |
 | `DOCKER_HUB_ACCESS_TOKEN` | Docker Hub access token |
+| `AWS_ACCESS_KEY_ID` | AWS credentials for ECR push |
+| `AWS_SECRET_ACCESS_KEY` | AWS credentials for ECR push |
 | `SSH_PRIVATE_KEY` | SSH key for deployment server |
 | `SSH_HOST` | Deployment server hostname |
 | `SSH_USER` | SSH username |


### PR DESCRIPTION
This pull request updates the Docker build workflows for both the server and web components to push images to multiple registries (Docker Hub, Amazon ECR Private, and Amazon ECR Public) instead of just Docker Hub. It also adds AWS credential configuration steps and updates the documentation to reflect these changes. The workflows now support broader deployment options and improved documentation for registry targets and required secrets.

Workflow enhancements for multi-registry support:

* Updated `server-build.yml` and `web-build.yml` to push Docker images to Docker Hub, ECR Private, and ECR Public by adding new environment variables and modifying the `docker/metadata-action` step to include all three registries. [[1]](diffhunk://#diff-23e0a86d8bc12f6a5f199be47ab68479e2ba8d0e8dfb7aabb898b94393cfe505L12-R21) [[2]](diffhunk://#diff-19b023023d9d583fbe12c89870c1353adccb781f831111f536a839655eaecf94L12-R21) [[3]](diffhunk://#diff-23e0a86d8bc12f6a5f199be47ab68479e2ba8d0e8dfb7aabb898b94393cfe505R37-R62) [[4]](diffhunk://#diff-19b023023d9d583fbe12c89870c1353adccb781f831111f536a839655eaecf94R37-R62)
* Added steps to configure AWS credentials and log in to both ECR Private and ECR Public registries, gated to only run on non-pull-request events. [[1]](diffhunk://#diff-23e0a86d8bc12f6a5f199be47ab68479e2ba8d0e8dfb7aabb898b94393cfe505R37-R62) [[2]](diffhunk://#diff-19b023023d9d583fbe12c89870c1353adccb781f831111f536a839655eaecf94R37-R62)

Documentation updates:

* Revised the `README.md` to explain the new multi-registry push, update workflow descriptions, and list the required AWS secrets for ECR access. Added a table summarizing image locations in Docker Hub and ECR Public.

Workflow output improvements:

* Changed the workflow summary output to list all registries where images are published, rather than just Docker Hub. [[1]](diffhunk://#diff-23e0a86d8bc12f6a5f199be47ab68479e2ba8d0e8dfb7aabb898b94393cfe505L61-R85) [[2]](diffhunk://#diff-19b023023d9d583fbe12c89870c1353adccb781f831111f536a839655eaecf94L60-R84)